### PR TITLE
updated NSDateFormatter extension to include option for fractional seconds

### DIFF
--- a/Sources/Extensions/Foundation/NSDateFormatter.swift
+++ b/Sources/Extensions/Foundation/NSDateFormatter.swift
@@ -3,11 +3,21 @@ import Foundation
 
 public extension DateFormatter {
 
+	@available(*, deprecated, message: "use 'iso8601Formatter(withFractionalSeconds: Bool)' instead")
 	@nonobjc
-	public static let iso8859Formatter: DateFormatter = {
-		let formatter = DateFormatter()
-		formatter.locale = Locale.englishUnitedStatesComputer
-		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-		return formatter
-	}()
+	public static let iso8859Formatter: DateFormatter = iso8601Formatter()
+
+	@nonobjc
+	public static func iso8601Formatter(withFractionalSeconds: Bool = false) -> DateFormatter {
+		let isoFormatter = DateFormatter()
+		isoFormatter.locale = Locale.englishUnitedStatesComputer
+		if withFractionalSeconds {
+			isoFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+		}
+		else {
+			isoFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+		}
+		
+		return isoFormatter
+	}
 }

--- a/Sources/Extensions/Foundation/NSDateFormatter.swift
+++ b/Sources/Extensions/Foundation/NSDateFormatter.swift
@@ -3,21 +3,37 @@ import Foundation
 
 public extension DateFormatter {
 
+	@nonobjc
+	private static let iso8601Formatter: DateFormatter = {
+		let formatter = DateFormatter()
+		formatter.locale = Locale.englishUnitedStatesComputer
+		formatter.timeZone = TimeZone(secondsFromGMT: 0)
+		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+
+		return formatter
+	}()
+
+	@nonobjc
+	private static let iso8601FormatterWithFractionalSeconds: DateFormatter = {
+		let formatter = DateFormatter()
+		formatter.locale = Locale.englishUnitedStatesComputer
+		formatter.timeZone = TimeZone(secondsFromGMT: 0)
+		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+
+		return formatter
+	}()
+
 	@available(*, deprecated, message: "use 'iso8601Formatter(withFractionalSeconds: Bool)' instead")
 	@nonobjc
-	public static let iso8859Formatter: DateFormatter = iso8601Formatter()
+	public static let iso8859Formatter: DateFormatter = iso8601Formatter
+
 
 	@nonobjc
 	public static func iso8601Formatter(withFractionalSeconds: Bool = false) -> DateFormatter {
-		let isoFormatter = DateFormatter()
-		isoFormatter.locale = Locale.englishUnitedStatesComputer
 		if withFractionalSeconds {
-			isoFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
-		}
-		else {
-			isoFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+			return iso8601FormatterWithFractionalSeconds
 		}
 		
-		return isoFormatter
+		return iso8601Formatter
 	}
 }


### PR DESCRIPTION
default option for iso8601 is with fractional seconds so having the option to get a parser with that should help